### PR TITLE
Update python_version for 3.13

### DIFF
--- a/msgraphforsharepoint.json
+++ b/msgraphforsharepoint.json
@@ -7,7 +7,7 @@
     "logo": "logo_msgraphforsharepoint.svg",
     "logo_dark": "logo_msgraphforsharepoint_dark.svg",
     "product_name": "SharePoint",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2022-2025 Splunk Inc.",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)