### PR TITLE
fix: sanitize infinity values for json conversion

### DIFF
--- a/msgraphforsharepoint_connector.py
+++ b/msgraphforsharepoint_connector.py
@@ -14,6 +14,7 @@
 # and limitations under the License.
 
 import json
+import math
 import os
 import sys
 import tempfile
@@ -669,6 +670,20 @@ class MsGraphForSharepointConnector(BaseConnector):
         self.save_progress("Test Connectivity Passed")
         return action_result.set_status(phantom.APP_SUCCESS)
 
+    def _sanitize_non_finite_floats(self, data):
+        """Recursively replace non-finite float values (Infinity, -Infinity, NaN) with None.
+
+        PostgreSQL's JSONB type rejects these values because they are not valid JSON.
+        The MS Graph API can return them in column metadata (e.g., "maximum": Infinity).
+        """
+        if isinstance(data, dict):
+            return {k: self._sanitize_non_finite_floats(v) for k, v in data.items()}
+        if isinstance(data, list):
+            return [self._sanitize_non_finite_floats(item) for item in data]
+        if isinstance(data, float) and not math.isfinite(data):
+            return None
+        return data
+
     def _paginator(self, action_result, endpoint, limit=None, params=None):
         """
         This action is used to create an iterator that will paginate through responses from called methods.
@@ -921,7 +936,7 @@ class MsGraphForSharepointConnector(BaseConnector):
             return action_result.get_status()
 
         response["items"] = list_items
-        action_result.add_data(response)
+        action_result.add_data(self._sanitize_non_finite_floats(response))
         summary = action_result.update_summary({})
         summary[MS_SHAREPOINT_JSON_ITEM_COUNT] = len(response.get("items", []))
 


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- The MS Graph API returns SharePoint list column metadata containing "maximum": Infinity, which is a valid Python float but not valid JSON per the JSON spec. When the SOAR platform attempted to save the action result to PostgreSQL's JSONB column, it failed with invalid input syntax for type json: Token "Infinity" is invalid, causing the "Failed to save app run" error. The fix adds a _sanitize_non_finite_floats() helper method to the connector that recursively walks the response data and replaces any non-finite float values (Infinity, -Infinity, NaN) with None (JSON null) before passing the result to add_data() in _handle_get_list.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
