### PR TITLE
Get file fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
 **drive_id** | required | SharePoint Drive ID | string | |
 **item_id** | required | Item ID of the file | string | |
-**force_infected_download** | optional | Download the file even if Microsoft flagged it as infected/malicious (sends 'Prefer: forceInfectedDownload'). Use for malware investigation | string | |
+**force_infected_download** | optional | Download the file even if Microsoft flagged it as infected/malicious (sends 'Prefer: forceInfectedDownload'). Use for malware investigation | boolean | |
 **file_path** | optional | Path to file relative to drive root | string | |
 
 #### Action Output

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MS Graph for SharePoint
 
 Publisher: Splunk <br>
-Connector Version: 1.5.3 <br>
+Connector Version: 1.5.4 <br>
 Product Vendor: Microsoft <br>
 Product Name: SharePoint <br>
 Minimum Product Version: 6.3.0
@@ -150,6 +150,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 [get file](#action-get-file) - Retrieves a file from a SharePoint site <br>
 [remove file](#action-remove-file) - Removes a file from a SharePoint site <br>
 [remove folder](#action-remove-folder) - Removes a folder from a SharePoint site
+[search file](#action-search-file) - Search for files/folders in a SharePoint drive by name or content
 
 ## action: 'test connectivity'
 
@@ -808,57 +809,35 @@ Retrieves a file from a SharePoint site
 Type: **generic** <br>
 Read only: **False**
 
-The 'file path' parameter will be considered from the <b>Shared Document</b> library in the configured Site. If the file is available under the <b>Shared Document</b> library itself, then provide only the '/' value in the 'file path' parameter.
+Download a file from a SharePoint site and add it to the vault.
 
 #### Action Parameters
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**file_name** | required | File name to retrieve | string | |
-**file_path** | required | Folder path on site | string | |
-**drive_id** | optional | The file is searched in this drive. If no drive is specified, the default drive will be used | string | `sharepoint drive id` |
+**drive_id** | required | SharePoint Drive ID | string | |
+**item_id** | required | Item ID of the file | string | |
+**force_infected_download** | optional | Download the file even if Microsoft flagged it as infected/malicious (sends 'Prefer: forceInfectedDownload'). Use for malware investigation | string | |
+**file_path** | optional | Path to file relative to drive root | string | |
 
 #### Action Output
 
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
-action_result.status | string | | success failed |
-action_result.parameter.file_name | string | | test_file_name.txt |
-action_result.parameter.file_path | string | | /test_folder_name/ |
-action_result.parameter.drive_id | string | `sharepoint drive id` | b!6UNv3PpUOUqHgzFOO7vtQcRIK8S5WfFIuW7oFFtVOfpd0Y9Jee8LTIrExOon7Yvi |
-action_result.data.\*.@microsoft.graph.downloadUrl | string | `url` | https://test-tenant-name.sharepoint.com/sites/TestSiteName/\_layouts/15/download.aspx?UniqueId=c743b2e0-36ec-4c8a-9ce0-190c2fd4dd97&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub0&ApiVersion=2.0 |
-action_result.data.\*.@odata.context | string | `url` | https://graph.test.com/v1.0/$metadata#sites('tenant-name.sharepoint.com%2Cdc6f43e9-54fa-4a39-8783-314e3bbbed41%2Cc42b48c4-59b9-48f1-b96e-e8145b5539fb')/drive/root/$entity |
-action_result.data.\*.image.width | numeric | | 256 |
-action_result.data.\*.image.height | numeric | | 266 |
-action_result.data.\*.cTag | string | | "c:{C743B2E0-36EB-4C9A-9CE0-190C2FD4DD97},1" |
-action_result.data.\*.createdBy.user.displayName | string | | Test User |
-action_result.data.\*.createdBy.user.email | string | `email` | test_user@tenant-name.ontest.com |
-action_result.data.\*.createdBy.user.id | string | | eeb3645f-df19-47a1-8e8c-fcd234cb5f6f |
-action_result.data.\*.createdDateTime | string | | 2022-02-10T15:25:21Z |
-action_result.data.\*.eTag | string | | "{C743B2E0-36EB-4C9A-9CE0-190C2FD4DD97},1" |
-action_result.data.\*.file.hashes.quickXorHash | string | | EIDYEgye8dEx3XhA7xc12GqSwxk= |
-action_result.data.\*.file.mimeType | string | | text/plain |
-action_result.data.\*.fileSystemInfo.createdDateTime | string | | 2022-02-10T15:25:21Z |
-action_result.data.\*.fileSystemInfo.lastModifiedDateTime | string | | 2022-02-10T15:25:21Z |
-action_result.data.\*.id | string | `sharepoint drive item id` | 01SNFLYIXAWJB4P2ZWTJGJZYAZBQX5JXMX |
-action_result.data.\*.lastModifiedBy.user.displayName | string | | Test User |
-action_result.data.\*.lastModifiedBy.user.email | string | `email` | test_user@tenant-name.ontest.com |
-action_result.data.\*.lastModifiedBy.user.id | string | | eeb3645f-df19-47a1-8e8c-fcd234cb5f6f |
-action_result.data.\*.lastModifiedDateTime | string | | 2022-02-10T15:25:21Z |
-action_result.data.\*.name | string | | test_file_name.txt |
-action_result.data.\*.parentReference.driveId | string | `sharepoint drive id` | b!6UNv3PpUOUqHgzFOO7vtQcRIK8S5WfFIuW7oFFtVOfpd0Y9Jee8LTIrExOon7Yvi |
-action_result.data.\*.parentReference.driveType | string | | documentLibrary |
-action_result.data.\*.parentReference.id | string | `sharepoint drive item id` | 01SNFLYIRDSQLQVWP7EVDKSL3YYUNW6I4G |
-action_result.data.\*.parentReference.name | string | | Playbook-Folder |
-action_result.data.\*.parentReference.path | string | | /drive/root:/test_folder_name |
-action_result.data.\*.parentReference.siteId | string | | dc6f43e9-54fa-4a39-8783-314e3bbbed41 |
-action_result.data.\*.shared.scope | string | | users |
-action_result.data.\*.size | numeric | | 1422 |
-action_result.data.\*.webUrl | string | `url` | https://test-tenant-name.sharepoint.com/sites/TestSiteName/Shared%20Documents/test_folder_name/test_file_name.txt |
+action_result.parameter.drive_id | string | `sharepoint drive id` |
+action_result.parameter.item_id | string | `sharepoint item id` |
+action_result.parameter.file_path | string | |
+action_result.parameter.force_infected_download | boolean | |
+action_result.data.*.vault_id | string | `sha1` `vault id` | 8b11ac28c0e276a4f9fa8a2fd2a17b499a415786 |
+action_result.data.*.file_name | string | `file name` |
+action_result.data.*.file_size | numeric | |
+action_result.data.*.malware_flagged | boolean | |
+action_result.data.*.force_infected_download | boolean | |
 action_result.summary.vault_id | string | `sha1` `vault id` | 8b11ac28c0e276a4f9fa8a2fd2a17b499a415786 |
-action_result.message | string | | Vault id: 8b11ac28c0e276a4f9fa8a2fd2a17b499a415786 |
-summary.total_objects | numeric | | 1 |
-summary.total_objects_successful | numeric | | 1 |
+action_result.summary.file_name | string | `file name` | |
+action_result.summary.malware_flagged | boolean | |
+action_result.status | string | |
+action_result.message | string | |
 
 ## action: 'remove file'
 
@@ -920,6 +899,47 @@ action_result.message | string | | Successfully deleted folder |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
 
+
+## action: 'search file'
+
+Removes a folder from a SharePoint site
+
+Type: **generic** <br>
+Read only: **True**
+
+
+#### Action Parameters
+
+PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
+--------- | -------- | ----------- | ---- | --------
+**drive_id"** | required | Drive ID to search within | string | |
+**search_text** | required | Text to search for (matches file/folder names and content) | string | |
+**folder_id"** | optional | Optional: limit search to a specific folder item ID | string | |
+**max_results"** | optional | Maximum number of results to return (default 100) | string | |
+
+#### Action Output
+
+DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
+--------- | ---- | -------- | --------------
+action_result.parameter.drive_id | string | `sharepoint drive id` |
+action_result.parameter.search_text | string | |
+action_result.parameter.folder_id | string | `sharepoint item id` |
+action_result.parameter.max_results | numeric | |
+action_result.data.*.id | string | `sharepoint item id` |
+action_result.data.*.name | string | `file name` |
+action_result.data.*.drive_id | string | `sharepoint drive id` | b!6UNv3PpUOUqHgzFOO7vtQcRIK8S5WfFIuW7oFFtVOfpd0Y9Jee8LTIrExOon7Yvi |
+action_result.data.*.size | numeric | |
+action_result.data.*.is_folder | boolean | |
+action_result.data.*.web_url | string | `url` |
+action_result.data.*.mime_type | string | |
+action_result.data.*.sha256 | string | `sha256` |
+action_result.data.*.created_by | string | |
+action_result.data.*.last_modified_by | string | |
+action_result.data.*.last_modified_datetime | string | |
+action_result.data.*.created_datetime | string | |
+action_result.summary.total_items_found | numeric | |
+action_result.status | string | |
+action_result.message | string | |
 ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.

--- a/README.md
+++ b/README.md
@@ -912,10 +912,10 @@ Read only: **True**
 
 PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 --------- | -------- | ----------- | ---- | --------
-**drive_id"** | required | Drive ID to search within | string | |
+**drive_id** | required | Drive ID to search within | string | |
 **search_text** | required | Text to search for (matches file/folder names and content) | string | |
-**folder_id"** | optional | Optional: limit search to a specific folder item ID | string | |
-**max_results"** | optional | Maximum number of results to return (default 100) | string | |
+**folder_id** | optional | Optional: limit search to a specific folder item ID | string | |
+**max_results** | optional | Maximum number of results to return (default 100) | string | |
 
 #### Action Output
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 [update item](#action-update-item) - Update an item in a list on a SharePoint Site <br>
 [get file](#action-get-file) - Retrieves a file from a SharePoint site <br>
 [remove file](#action-remove-file) - Removes a file from a SharePoint site <br>
-[remove folder](#action-remove-folder) - Removes a folder from a SharePoint site
+[remove folder](#action-remove-folder) - Removes a folder from a SharePoint site <br>
 [search file](#action-search-file) - Search for files/folders in a SharePoint drive by name or content
 
 ## action: 'test connectivity'
@@ -902,7 +902,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 ## action: 'search file'
 
-Removes a folder from a SharePoint site
+Search for files/folders in a SharePoint drive by name or content
 
 Type: **generic** <br>
 Read only: **True**

--- a/msgraphforsharepoint.json
+++ b/msgraphforsharepoint.json
@@ -11,7 +11,7 @@
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2022-2026 Splunk Inc.",
-    "app_version": "1.5.3",
+    "app_version": "1.5.4",
     "utctime_updated": "2026-04-24T21:34:49.289896Z",
     "package_name": "phantom_msgraphforsharepoint",
     "main_module": "msgraphforsharepoint_connector.py",
@@ -234,6 +234,69 @@
                     "data_type": "numeric",
                     "example_values": [
                         1
+                    ]
+                }
+            ],
+            "render": {
+                "type": "table"
+            },
+            "versions": "EQ(*)"
+        },
+        {
+            "action": "get drive id",
+            "identifier": "get_drive_id",
+            "description": "Get a user's OneDrive drive ID from Microsoft Graph",
+            "type": "investigate",
+            "read_only": true,
+            "parameters": {
+                "user_id": {
+                    "description": "User ID or user principal name",
+                    "data_type": "string",
+                    "required": true,
+                    "contains": [
+                        "azure user id",
+                        "email"
+                    ],
+                    "order": 0,
+                    "primary": true
+                }
+            },
+            "output": [
+                {
+                    "data_path": "action_result.data.*.id",
+                    "data_type": "string",
+                    "contains": [
+                        "sharepoint drive id"
+                    ],
+                    "column_name": "Drive ID",
+                    "column_order": 0
+                },
+                {
+                    "data_path": "action_result.data.*.driveType",
+                    "data_type": "string",
+                    "column_name": "Drive Type",
+                    "column_order": 1
+                },
+                {
+                    "data_path": "action_result.data.*.owner.user.displayName",
+                    "data_type": "string",
+                    "column_name": "Owner",
+                    "column_order": 2
+                },
+                {
+                    "data_path": "action_result.data.*.webUrl",
+                    "data_type": "string",
+                    "contains": [
+                        "url"
+                    ],
+                    "column_name": "Web URL",
+                    "column_order": 3
+                },
+                {
+                    "data_path": "action_result.summary.drive_id",
+                    "data_type": "string",
+                    "contains": [
+                        "sharepoint drive id"
                     ]
                 }
             ],
@@ -1171,41 +1234,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.data.*.image.width",
-                    "data_type": "numeric",
-                    "example_values": [
-                        1752
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.image.height",
-                    "data_type": "numeric",
-                    "example_values": [
-                        1244
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.cTag",
-                    "data_type": "string",
-                    "example_values": [
-                        "\"c:{E1E93D43-F034-489F-8304-BAF7F064A30D},0\""
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.createdBy.user.displayName",
-                    "data_type": "string",
-                    "example_values": [
-                        "SharePoint App"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.createdBy.user.email",
-                    "data_type": "string",
-                    "example_values": [
-                        "test@gmail.com"
-                    ]
-                },
-                {
                     "data_path": "action_result.data.*.createdBy.user.id",
                     "data_type": "string",
                     "example_values": [
@@ -1217,27 +1245,6 @@
                     "data_type": "string",
                     "example_values": [
                         "2020-07-28T20:15:33Z"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.decorator.iconColor",
-                    "data_type": "string",
-                    "example_values": [
-                        "darkGreen"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.eTag",
-                    "data_type": "string",
-                    "example_values": [
-                        "\"{E1E93D43-F034-489F-8304-BAF7F064A30D},1\""
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.file.hashes.quickXorHash",
-                    "data_type": "string",
-                    "example_values": [
-                        "8JpxaQB3wX1/FkQ5Gt3prUbUUFU="
                     ]
                 },
                 {
@@ -3437,335 +3444,105 @@
         {
             "action": "get file",
             "identifier": "get_file",
-            "description": "Retrieves a file from a SharePoint site",
-            "verbose": "The 'file path' parameter will be considered from the <b>Shared Document</b> library in the configured Site. If the file is available under the <b>Shared Document</b> library itself, then provide only the '/' value in the 'file path' parameter.",
-            "type": "generic",
+            "description": "Download a file from a SharePoint site and add it to the vault",
+            "verbose": "Retrieves a file from SharePoint via MS Graph and stores it in the SOAR vault for analysis.",
+            "type": "investigate",
             "read_only": false,
             "parameters": {
-                "file_name": {
-                    "description": "File name to retrieve",
+                "drive_id": {
+                    "description": "SharePoint Drive ID",
                     "data_type": "string",
                     "required": true,
-                    "order": 0
+                    "order": 0,
+                    "contains": [
+                        "sharepoint drive id"
+                    ]
+                },
+                "item_id": {
+                    "description": "Item ID of the file",
+                    "data_type": "string",
+                    "required": true,
+                    "order": 1,
+                    "contains": [
+                        "sharepoint item id"
+                    ]
+                },
+                "force_infected_download": {
+                    "description": "Download the file even if Microsoft flagged it as infected/malicious (sends 'Prefer: forceInfectedDownload'). Use for malware investigation.",
+                    "data_type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "order": 2
                 },
                 "file_path": {
-                    "description": "Folder path on site",
-                    "data_type": "string",
-                    "required": true,
-                    "order": 1
-                },
-                "drive_id": {
-                    "description": "The file is searched in this drive. If no drive is specified, the default drive will be used",
+                    "description": "Path to file relative to drive root (alternative to item_id)",
                     "data_type": "string",
                     "required": false,
                     "order": 2,
-                    "example_values": [
-                        "b!6UNv3PpUOUqHgzFOO7vtQcRIK8S5WfFIuW7oFFtVOfpd0Y9Jee8LTIrExOon7Yvi"
-                    ],
                     "contains": [
-                        "sharepoint drive id"
+                        "file path"
                     ]
                 }
             },
             "output": [
                 {
-                    "data_path": "action_result.status",
+                    "data_path": "action_result.parameter.drive_id",
                     "data_type": "string",
-                    "example_values": [
-                        "success",
-                        "failed"
+                    "contains": [
+                        "sharepoint drive id"
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.file_name",
+                    "data_path": "action_result.parameter.item_id",
                     "data_type": "string",
-                    "example_values": [
-                        "test_file_name.txt"
+                    "contains": [
+                        "sharepoint item id"
                     ]
                 },
                 {
                     "data_path": "action_result.parameter.file_path",
                     "data_type": "string",
-                    "example_values": [
-                        "/test_folder_name/"
-                    ]
-                },
-                {
-                    "data_path": "action_result.parameter.drive_id",
-                    "data_type": "string",
-                    "example_values": [
-                        "b!6UNv3PpUOUqHgzFOO7vtQcRIK8S5WfFIuW7oFFtVOfpd0Y9Jee8LTIrExOon7Yvi"
-                    ],
                     "contains": [
-                        "sharepoint drive id"
+                        "sharepoint file path id"
                     ]
                 },
                 {
-                    "data_path": "action_result.data.*.@microsoft.graph.downloadUrl",
+                    "data_path": "action_result.parameter.force_infected_download",
+                    "data_type": "boolean"
+                },
+                {
+                    "data_path": "action_result.data.*.vault_id",
                     "data_type": "string",
-                    "example_values": [
-                        "https://test-tenant-name.sharepoint.com/sites/TestSiteName/_layouts/15/download.aspx?UniqueId=c743b2e0-36ec-4c8a-9ce0-190c2fd4dd97&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub0&ApiVersion=2.0"
-                    ],
                     "contains": [
-                        "url"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.@odata.context",
-                    "data_type": "string",
-                    "example_values": [
-                        "https://graph.test.com/v1.0/$metadata#sites('tenant-name.sharepoint.com%2Cdc6f43e9-54fa-4a39-8783-314e3bbbed41%2Cc42b48c4-59b9-48f1-b96e-e8145b5539fb')/drive/root/$entity"
+                        "SOAR vault id"
                     ],
-                    "contains": [
-                        "url"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.image.width",
-                    "data_type": "numeric",
-                    "example_values": [
-                        256
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.image.height",
-                    "data_type": "numeric",
-                    "example_values": [
-                        266
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.cTag",
-                    "data_type": "string",
-                    "example_values": [
-                        "\"c:{C743B2E0-36EB-4C9A-9CE0-190C2FD4DD97},1\""
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.createdBy.user.displayName",
-                    "data_type": "string",
-                    "example_values": [
-                        "Test User"
-                    ],
-                    "column_name": "Created By",
-                    "column_order": 1
-                },
-                {
-                    "data_path": "action_result.data.*.createdBy.user.email",
-                    "data_type": "string",
-                    "example_values": [
-                        "test_user@tenant-name.ontest.com"
-                    ],
-                    "contains": [
-                        "email"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.createdBy.user.id",
-                    "data_type": "string",
-                    "example_values": [
-                        "eeb3645f-df19-47a1-8e8c-fcd234cb5f6f"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.createdDateTime",
-                    "data_type": "string",
-                    "example_values": [
-                        "2022-02-10T15:25:21Z"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.eTag",
-                    "data_type": "string",
-                    "example_values": [
-                        "\"{C743B2E0-36EB-4C9A-9CE0-190C2FD4DD97},1\""
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.file.hashes.quickXorHash",
-                    "data_type": "string",
-                    "example_values": [
-                        "EIDYEgye8dEx3XhA7xc12GqSwxk="
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.file.mimeType",
-                    "data_type": "string",
-                    "example_values": [
-                        "text/plain"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.fileSystemInfo.createdDateTime",
-                    "data_type": "string",
-                    "example_values": [
-                        "2022-02-10T15:25:21Z"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.fileSystemInfo.lastModifiedDateTime",
-                    "data_type": "string",
-                    "example_values": [
-                        "2022-02-10T15:25:21Z"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.id",
-                    "data_type": "string",
-                    "example_values": [
-                        "01SNFLYIXAWJB4P2ZWTJGJZYAZBQX5JXMX"
-                    ],
-                    "contains": [
-                        "sharepoint drive item id"
-                    ],
-                    "column_name": "Drive Item ID",
+                    "column_name": "Vault ID",
                     "column_order": 0
                 },
                 {
-                    "data_path": "action_result.data.*.lastModifiedBy.user.displayName",
+                    "data_path": "action_result.data.*.file_name",
                     "data_type": "string",
-                    "example_values": [
-                        "Test User"
-                    ],
-                    "column_name": "Last Modified By",
-                    "column_order": 2
-                },
-                {
-                    "data_path": "action_result.data.*.lastModifiedBy.user.email",
-                    "data_type": "string",
-                    "example_values": [
-                        "test_user@tenant-name.ontest.com"
-                    ],
                     "contains": [
-                        "email"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.lastModifiedBy.user.id",
-                    "data_type": "string",
-                    "example_values": [
-                        "eeb3645f-df19-47a1-8e8c-fcd234cb5f6f"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.lastModifiedDateTime",
-                    "data_type": "string",
-                    "example_values": [
-                        "2022-02-10T15:25:21Z"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.name",
-                    "data_type": "string",
-                    "example_values": [
-                        "test_file_name.txt"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.parentReference.driveId",
-                    "data_type": "string",
-                    "example_values": [
-                        "b!6UNv3PpUOUqHgzFOO7vtQcRIK8S5WfFIuW7oFFtVOfpd0Y9Jee8LTIrExOon7Yvi"
+                        "file name"
                     ],
-                    "contains": [
-                        "sharepoint drive id"
-                    ],
-                    "column_name": "Drive ID",
-                    "column_order": 3
+                    "column_name": "File Name",
+                    "column_order": 1
                 },
                 {
-                    "data_path": "action_result.data.*.parentReference.driveType",
-                    "data_type": "string",
-                    "example_values": [
-                        "documentLibrary"
-                    ]
+                    "data_path": "action_result.data.*.malware_flagged",
+                    "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.parentReference.id",
-                    "data_type": "string",
-                    "example_values": [
-                        "01SNFLYIRDSQLQVWP7EVDKSL3YYUNW6I4G"
-                    ],
-                    "contains": [
-                        "sharepoint drive item id"
-                    ]
+                    "data_path": "action_result.data.*.file_size",
+                    "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.parentReference.name",
-                    "data_type": "string",
-                    "example_values": [
-                        "Playbook-Folder"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.parentReference.path",
-                    "data_type": "string",
-                    "example_values": [
-                        "/drive/root:/test_folder_name"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.parentReference.siteId",
-                    "data_type": "string",
-                    "example_values": [
-                        "dc6f43e9-54fa-4a39-8783-314e3bbbed41"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.shared.scope",
-                    "data_type": "string",
-                    "example_values": [
-                        "users"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.size",
-                    "data_type": "numeric",
-                    "example_values": [
-                        1422
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.webUrl",
-                    "data_type": "string",
-                    "example_values": [
-                        "https://test-tenant-name.sharepoint.com/sites/TestSiteName/Shared%20Documents/test_folder_name/test_file_name.txt"
-                    ],
-                    "contains": [
-                        "url"
-                    ]
-                },
-                {
-                    "data_path": "action_result.summary.vault_id",
-                    "data_type": "string",
-                    "example_values": [
-                        "8b11ac28c0e276a4f9fa8a2fd2a17b499a415786"
-                    ],
-                    "contains": [
-                        "sha1",
-                        "vault id"
-                    ]
+                    "data_path": "action_result.status",
+                    "data_type": "string"
                 },
                 {
                     "data_path": "action_result.message",
-                    "data_type": "string",
-                    "example_values": [
-                        "Vault id: 8b11ac28c0e276a4f9fa8a2fd2a17b499a415786"
-                    ]
-                },
-                {
-                    "data_path": "summary.total_objects",
-                    "data_type": "numeric",
-                    "example_values": [
-                        1
-                    ]
-                },
-                {
-                    "data_path": "summary.total_objects_successful",
-                    "data_type": "numeric",
-                    "example_values": [
-                        1
-                    ]
+                    "data_type": "string"
                 }
             ],
             "render": {
@@ -3865,6 +3642,151 @@
                     "example_values": [
                         1
                     ]
+                }
+            ],
+            "render": {
+                "type": "table"
+            },
+            "versions": "EQ(*)"
+        },
+        {
+            "action": "search file",
+            "identifier": "search_file",
+            "description": "Search for files/folders in a SharePoint drive by name or content",
+            "verbose": "Uses the MS Graph driveItem search API to find items matching a query string within a drive (or a specific folder). Returns drive_id and item id for use with the 'get file' action.",
+            "type": "investigate",
+            "read_only": true,
+            "parameters": {
+                "drive_id": {
+                    "description": "Drive ID to search within",
+                    "data_type": "string",
+                    "required": true,
+                    "order": 0,
+                    "contains": [
+                        "sharepoint drive id"
+                    ]
+                },
+                "search_text": {
+                    "description": "Text to search for (matches file/folder names and content)",
+                    "data_type": "string",
+                    "required": true,
+                    "order": 1
+                },
+                "folder_id": {
+                    "description": "Optional: limit search to a specific folder item ID",
+                    "data_type": "string",
+                    "required": false,
+                    "order": 2,
+                    "contains": [
+                        "sharepoint item id"
+                    ]
+                },
+                "max_results": {
+                    "description": "Maximum number of results to return (default 100)",
+                    "data_type": "numeric",
+                    "required": false,
+                    "default": 100,
+                    "order": 3
+                }
+            },
+            "output": [
+                {
+                    "data_path": "action_result.parameter.drive_id",
+                    "data_type": "string",
+                    "contains": [
+                        "sharepoint drive id"
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.search_text",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.parameter.folder_id",
+                    "data_type": "string",
+                    "contains": [
+                        "sharepoint item id"
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.max_results",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.data.*.id",
+                    "data_type": "string",
+                    "contains": [
+                        "sharepoint item id"
+                    ],
+                    "column_name": "Item ID",
+                    "column_order": 1
+                },
+                {
+                    "data_path": "action_result.data.*.name",
+                    "data_type": "string",
+                    "contains": [
+                        "file name"
+                    ],
+                    "column_name": "Name",
+                    "column_order": 0
+                },
+                {
+                    "data_path": "action_result.data.*.drive_id",
+                    "data_type": "string",
+                    "contains": [
+                        "sharepoint drive id"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.size",
+                    "data_type": "numeric",
+                    "column_name": "Size",
+                    "column_order": 2
+                },
+                {
+                    "data_path": "action_result.data.*.is_folder",
+                    "data_type": "boolean"
+                },
+                {
+                    "data_path": "action_result.data.*.web_url",
+                    "data_type": "string",
+                    "contains": [
+                        "url"
+                    ],
+                    "column_name": "Web URL",
+                    "column_order": 3
+                },
+                {
+                    "data_path": "action_result.data.*.mime_type",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.created_by",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.last_modified_by",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.last_modified_datetime",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.created_datetime",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.summary.total_items_found",
+                    "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.status",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.message",
+                    "data_type": "string"
                 }
             ],
             "render": {

--- a/msgraphforsharepoint_connector.py
+++ b/msgraphforsharepoint_connector.py
@@ -573,6 +573,40 @@ class MsGraphForSharepointConnector(BaseConnector):
             )
 
         return phantom.APP_SUCCESS, phantom_base_url
+    
+    def _handle_get_drive_id(self, param):
+        action_result = self.add_action_result(ActionResult(dict(param)))
+
+        user_id = param.get("user_id")
+        if not user_id:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                "Missing required parameter: user_id"
+            )
+
+        user_id = urllib.parse.quote(user_id)
+        endpoint = f"/users/{user_id}/drive"
+
+        ret_val, response = self._make_rest_call_helper(
+            endpoint,
+            action_result,
+            method="get"
+        )
+
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
+        action_result.add_data(response)
+
+        summary = action_result.update_summary({})
+        summary["drive_id"] = response.get("id")
+        summary["drive_type"] = response.get("driveType")
+        summary["owner"] = response.get("owner", {}).get("user", {}).get("displayName")
+
+        return action_result.set_status(
+            phantom.APP_SUCCESS,
+            f"Successfully retrieved drive ID: {response.get('id')}"
+        )
 
     def _get_url_to_app_rest(self, action_result=None):
         if not action_result:
@@ -945,42 +979,180 @@ class MsGraphForSharepointConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def _handle_get_file(self, param):
+        self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
 
-        if not self._site_id:
-            return action_result.set_status(phantom.APP_ERROR, MS_SHAREPOINT_ERROR_MISSING_SITE_ID.format("retrieving a file"))
+        drive_id = param["drive_id"]
+        item_id = param["item_id"]
+        force_infected = param.get("force_infected_download", False)
 
-        sp_path = urllib.parse.quote(param[MS_SHAREPOINT_JSON_FILE_PATH].strip("/"))
-        sp_file = urllib.parse.quote(param[MS_SHAREPOINT_JSON_FILE_NAME])
-        sp_drive = param.get(MS_SHAREPOINT_JSON_DRIVE_ID, "")
-        endpoint = f"{self.build_drive_endpoint(sp_drive)}{MS_GET_FILE_METADATA_ENDPOINT.format(path=sp_path, file=sp_file)}"
-
-        # Get the file metadata
-        ret_val, file_meta = self._make_rest_call_helper(endpoint, action_result)
+        meta_endpoint = f"/drives/{drive_id}/items/{item_id}"
+        ret_val, meta = self._make_rest_call_helper(
+            meta_endpoint, action_result, method="get"
+        )
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
-        # Get the file content
-        ret_val, tmp_file_path = self._make_rest_call_helper(MS_GET_FILE_CONTENT_ENDPOINT.format(endpoint), action_result, download=True)
-        if phantom.is_fail(ret_val):
-            return action_result.get_status()
+        file_name = meta.get("name", "sharepoint_file")
+        file_size = meta.get("size", 0)
+        self.save_progress(f"Found file '{file_name}' ({file_size} bytes)")
 
-        # Save attachment file to the vault
-        try:
-            success, message, attachment_vault_id = ph_rules.vault_add(
-                container=self.get_container_id(), file_location=tmp_file_path, file_name=sp_file
+        # Surface Microsoft's malware verdict if present (the 'malware' facet)
+        is_flagged = "malware" in meta
+        if is_flagged:
+            self.save_progress(
+                "Microsoft has flagged this item with a malware facet"
             )
-            if not success:
-                return action_result.set_status(phantom.APP_ERROR, message)
+
+        download_headers = None
+        if force_infected:
+            self.save_progress(
+                "force_infected_download enabled — sending "
+                "'Prefer: forceInfectedDownload' header"
+            )
+            # The helper will .update() this onto its own headers dict
+            download_headers = {"Prefer": "forceInfectedDownload"}
+
+        content_endpoint = f"/drives/{drive_id}/items/{item_id}/content"
+        ret_val, tmp_file_path = self._make_rest_call_helper(
+            content_endpoint,
+            action_result,
+            method="get",
+            download=True,
+            headers=download_headers,
+        )
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
+        try:
+            success, message, vault_id = ph_rules.vault_add(
+                container=self.get_container_id(),
+                file_location=tmp_file_path,
+                file_name=file_name,
+            )
         except Exception as e:
-            error_message = f"Unable to add file to the vault for attachment name: {sp_file}. Error: {self._get_error_message_from_exception(e)}"
-            return action_result.set_status(phantom.APP_ERROR, error_message)
+            return action_result.set_status(
+                phantom.APP_ERROR, f"Error adding file to vault: {e}"
+            )
 
-        action_result.add_data(file_meta)
+        if not success:
+            return action_result.set_status(
+                phantom.APP_ERROR, f"Failed to add file to vault: {message}"
+            )
+
+        action_result.add_data({
+            "vault_id": vault_id,
+            "file_name": file_name,
+            "file_size": file_size,
+            "malware_flagged": is_flagged,
+            "force_infected_download": force_infected,
+        })
         summary = action_result.update_summary({})
-        summary[MS_SHAREPOINT_JSON_VAULT_ID] = attachment_vault_id
+        summary["vault_id"] = vault_id
+        summary["file_name"] = file_name
+        summary["malware_flagged"] = is_flagged
 
-        return action_result.set_status(phantom.APP_SUCCESS)
+        return action_result.set_status(
+            phantom.APP_SUCCESS,
+            f"Successfully added '{file_name}' to vault (vault_id: {vault_id})"
+        )
+    
+    def _handle_search_file(self, param):
+
+        self.save_progress(f"In action handler for: {self.get_action_identifier()}")
+        action_result = self.add_action_result(ActionResult(dict(param)))
+
+        drive_id = param["drive_id"]
+        search_text = param["search_text"]
+        folder_id = param.get("folder_id")
+        max_results = int(param.get("max_results", 100))
+
+        # Escape single quotes for the OData function, then URL-encode
+        safe_query = search_text.replace("'", "''")
+        encoded_query = urllib.parse.quote(safe_query)
+
+        if folder_id:
+            base = f"/drives/{drive_id}/items/{folder_id}/search(q='{encoded_query}')"
+        else:
+            base = f"/drives/{drive_id}/root/search(q='{encoded_query}')"
+
+        select_fields = (
+            "id,name,size,webUrl,createdDateTime,lastModifiedDateTime,"
+            "file,folder,parentReference,createdBy,lastModifiedBy"
+        )
+        page_size = min(max_results, 200)
+        endpoint = f"{base}?$select={select_fields}&$top={page_size}"
+
+        total_found = 0
+        next_link = None
+
+        while True:
+            if next_link:
+                # endpoint is ignored when next_link is passed; helper uses next_link as the full URL
+                ret_val, response = self._make_rest_call_helper(
+                    endpoint, action_result, method="get", next_link=next_link
+                )
+            else:
+                ret_val, response = self._make_rest_call_helper(
+                    endpoint, action_result, method="get"
+                )
+
+            if phantom.is_fail(ret_val):
+                return action_result.get_status()
+
+            if not isinstance(response, dict):
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Unexpected response type from Graph: {type(response)}"
+                )
+
+            for item in response.get("value", []):
+                if total_found >= max_results:
+                    break
+
+                is_folder = "folder" in item
+                result = {
+                    "id": item.get("id"),
+                    "name": item.get("name"),
+                    "size": item.get("size", 0),
+                    "web_url": item.get("webUrl"),
+                    "is_folder": is_folder,
+                    "created_datetime": item.get("createdDateTime"),
+                    "last_modified_datetime": item.get("lastModifiedDateTime"),
+                    "created_by": item.get("createdBy", {})
+                                    .get("user", {}).get("displayName"),
+                    "last_modified_by": item.get("lastModifiedBy", {})
+                                            .get("user", {}).get("displayName"),
+                    "drive_id": item.get("parentReference", {}).get("driveId", drive_id),
+                    "parent_path": item.get("parentReference", {}).get("path"),
+                }
+                file_facet = item.get("file")
+                if file_facet:
+                    result["mime_type"] = file_facet.get("mimeType")
+                    hashes = file_facet.get("hashes", {})
+                    result["sha256"] = hashes.get("sha256Hash")
+                    result["quick_xor_hash"] = hashes.get("quickXorHash")
+
+                action_result.add_data(result)
+                total_found += 1
+
+            next_link = response.get("@odata.nextLink")
+            if not next_link or total_found >= max_results:
+                break
+
+        summary = action_result.update_summary({})
+        summary["total_items_found"] = total_found
+
+        if total_found == 0:
+            return action_result.set_status(
+                phantom.APP_SUCCESS, f"No items found matching '{search_text}'"
+            )
+
+        return action_result.set_status(
+            phantom.APP_SUCCESS,
+            f"Found {total_found} item(s) matching '{search_text}'"
+        )
+
 
     def _handle_remove_file(self, param):
         action_result = self.add_action_result(ActionResult(dict(param)))
@@ -1061,6 +1233,8 @@ class MsGraphForSharepointConnector(BaseConnector):
             ret_val = self._handle_get_list(param)
         elif action_id == "get_file":
             ret_val = self._handle_get_file(param)
+        elif action_id == "search_file":
+            ret_val = self._handle_search_file(param)
         elif action_id == "remove_file":
             ret_val = self._handle_remove_file(param)
         elif action_id == "list_lists":
@@ -1079,6 +1253,8 @@ class MsGraphForSharepointConnector(BaseConnector):
             ret_val = self._handle_list_drives(param)
         elif action_id == "list_folder_items":
             ret_val = self._handle_list_folder_items(param)
+        elif action_id == "get_drive_id":
+            ret_val = self._handle_get_drive_id(param)
         elif action_id == "remove_folder":
             ret_val = self._handle_remove_folder(param)
 


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

- New Action: 'search file' - Search for files/folders in a SharePoint drive by name or content
- Parameters: drive_id, search_text, folder_id, max_results
- No new auth method needed

- New Feature in 'get file' - Microsoft now lets you pass in a header to download a file they have marked as malicious. We need this capability for our SOC to download suspicious files for investigation. I have never been able to download a file with get file until these changes so I made a number of updates here. I ran 'get drive id' to get a drive id for a user, then run the new 'search file' action to find the file I want in the drive, then I use the updated 'get file' to pull the file into the vault.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [X] I have verified that manual documentation has been updated where appropriate

### Other information
A co-worker and I have never been able to download a SharePoint file using 'get file' until these updates

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
