### PR TITLE
fix: remediate SharePoint Graph security findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/msgraphforsharepoint_connector.py
+++ b/msgraphforsharepoint_connector.py
@@ -35,6 +35,23 @@ from phantom_common import paths
 from msgraphforsharepoint_consts import *
 
 
+def _is_expected_graph_url(url):
+    """Return whether an absolute URL targets the Microsoft Graph origin."""
+    try:
+        candidate = urllib.parse.urlsplit(str(url))
+        expected = urllib.parse.urlsplit(MS_GRAPH_BASE_URL)
+        port = candidate.port
+    except ValueError:
+        return False
+    return (
+        candidate.scheme == "https"
+        and candidate.hostname == expected.hostname
+        and port is None
+        and not candidate.username
+        and not candidate.password
+    )
+
+
 class RetVal(tuple):
     def __new__(cls, val1, val2=None):
         return tuple.__new__(RetVal, (val1, val2))
@@ -697,6 +714,7 @@ class MsGraphForSharepointConnector(BaseConnector):
 
         list_items = list()
         next_link = None
+        seen_links = set()
 
         # maximum page size
         page_size = MS_SHAREPOINT_PER_PAGE_COUNT
@@ -709,8 +727,13 @@ class MsGraphForSharepointConnector(BaseConnector):
         else:
             params = {"$top": page_size}
 
-        while True:
+        for _ in range(MS_SHAREPOINT_MAX_PAGINATION_PAGES):
             if next_link:
+                if not _is_expected_graph_url(next_link):
+                    return action_result.set_status(phantom.APP_ERROR, "Rejected pagination URL outside Microsoft Graph"), None
+                if next_link in seen_links:
+                    return action_result.set_status(phantom.APP_ERROR, "Rejected repeated Microsoft Graph pagination URL"), None
+                seen_links.add(next_link)
                 ret_val, response = self._make_rest_call_helper(endpoint, action_result, next_link=next_link)
             else:
                 ret_val, response = self._make_rest_call_helper(endpoint, action_result, params=params)
@@ -727,6 +750,8 @@ class MsGraphForSharepointConnector(BaseConnector):
             next_link = response.get("@odata.nextLink", None)
             if not next_link:
                 break
+        else:
+            return action_result.set_status(phantom.APP_ERROR, "Microsoft Graph pagination exceeded its safety limit"), None
 
         return phantom.APP_SUCCESS, list_items
 

--- a/msgraphforsharepoint_connector.py
+++ b/msgraphforsharepoint_connector.py
@@ -52,6 +52,15 @@ def _is_expected_graph_url(url):
     )
 
 
+def _is_token_response(response):
+    """Return whether a response came from the OAuth token endpoint."""
+    try:
+        url = urllib.parse.urlsplit(str(response.url))
+    except (AttributeError, ValueError):
+        return False
+    return url.scheme == "https" and url.hostname == "login.microsoftonline.com" and url.path.rstrip("/").endswith("/oauth2/v2.0/token")
+
+
 class RetVal(tuple):
     def __new__(cls, val1, val2=None):
         return tuple.__new__(RetVal, (val1, val2))
@@ -376,8 +385,11 @@ class MsGraphForSharepointConnector(BaseConnector):
         # store the r_text in debug data, it will get dumped in the logs if the action fails
         if hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": r.status_code})
-            action_result.add_debug_data({"r_text": r.text})
-            action_result.add_debug_data({"r_headers": r.headers})
+            if _is_token_response(r):
+                action_result.add_debug_data({"r_text": "<OAuth token response redacted>"})
+            else:
+                action_result.add_debug_data({"r_text": r.text})
+                action_result.add_debug_data({"r_headers": r.headers})
 
         # Process each 'Content-Type' of response separately
 

--- a/msgraphforsharepoint_connector.py
+++ b/msgraphforsharepoint_connector.py
@@ -1040,8 +1040,9 @@ class MsGraphForSharepointConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS, "Successfully deleted folder")
 
     def build_drive_endpoint(self, drive_id: str = ""):
+        encoded_drive_id = urllib.parse.quote(str(drive_id), safe="")
         return (
-            MS_CUSTOM_DRIVE_ROOT_ENDPOINT.format(site_id=self._site_id, drive_id=drive_id)
+            MS_CUSTOM_DRIVE_ROOT_ENDPOINT.format(site_id=self._site_id, drive_id=encoded_drive_id)
             if drive_id
             else MS_DRIVE_ROOT_ENDPOINT.format(site_id=self._site_id)
         )

--- a/msgraphforsharepoint_consts.py
+++ b/msgraphforsharepoint_consts.py
@@ -54,6 +54,7 @@ SOAR_ASSET_INFO_URL = "{url}rest/asset/{asset_id}"
 DEFAULT_REQUEST_TIMEOUT = 30  # in seconds
 STATE_FILE_PATH = "{0}/{1}_state.json"
 MS_SHAREPOINT_PER_PAGE_COUNT = 1000
+MS_SHAREPOINT_MAX_PAGINATION_PAGES = 1000
 
 # Status/Progress Messages
 MS_SHAREPOINT_ERROR_MSG = "Unknown error occurred. Please check the asset configuration and|or action parameters"

--- a/msgraphforsharepoint_list_lists.html
+++ b/msgraphforsharepoint_list_lists.html
@@ -119,7 +119,7 @@
                         {% if list.displayName %}
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sharepoint list name'], 'value': '{{ list.displayName }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sharepoint list name'], 'value': '{{ list.displayName|escapejs }}' }], 0, {{ container.id|escapejs }}, null, false);">
                               {{ list.displayName }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -131,7 +131,7 @@
                         {% if list.id %}
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sharepoint list id'], 'value': '{{ list.id }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sharepoint list id'], 'value': '{{ list.id|escapejs }}' }], 0, {{ container.id|escapejs }}, null, false);">
                               {{ list.id }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Encode caller-controlled drive identifiers as single Microsoft Graph path segments.
+* Restrict pagination to Microsoft Graph and bound page traversal.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Encode caller-controlled drive identifiers as single Microsoft Graph path segments.
 * Restrict pagination to Microsoft Graph and bound page traversal.
 * Escape list values embedded in widget context-menu JavaScript.
+* Redact OAuth token responses from action debug data.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Encode caller-controlled drive identifiers as single Microsoft Graph path segments.
 * Restrict pagination to Microsoft Graph and bound page traversal.
+* Escape list values embedded in widget context-menu JavaScript.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Encode caller-controlled drive identifiers as single Microsoft Graph path segments.


### PR DESCRIPTION
## Summary

- encode caller-controlled drive identifiers as single Graph path segments
- validate and bound Microsoft Graph pagination
- JavaScript-escape list values in widget context menus
- redact OAuth token responses from debug data
- refresh shared hooks

Tracks PAPP-38261. Addresses PSAAS-30681, PSAAS-30708, PSAAS-31129, PSAAS-31869, and PSAAS-32114 under ESPM-5228. Read-only-only findings were excluded and closed Invalid through the campaign workflow.

## Validation

- `pre-commit run --all-files`
- `python3 -m compileall -q -x .*/\.venv/.* .`

PR and changes prepared by Codex.

## Tracking

- PAPP: PAPP-38261
- PSAAS: PSAAS-30681, PSAAS-30708, PSAAS-31129, PSAAS-31869, PSAAS-32114
- Written by Codex.